### PR TITLE
Remove pointless toString

### DIFF
--- a/storage-units/src/main/java/de/xn__ho_hia/storage_unit/StorageUnit.java
+++ b/storage-units/src/main/java/de/xn__ho_hia/storage_unit/StorageUnit.java
@@ -614,8 +614,8 @@ public abstract class StorageUnit<T extends StorageUnit<T>> extends Number imple
 
     @NonNull
     private final BigDecimal calculate(final BigInteger base) {
-        return Nullsafe.nonNull(new BigDecimal(this.bytes.toString())
-                .divide(new BigDecimal(base.toString()), StorageUnit.DEFAULT_SCALE, RoundingMode.CEILING));
+        return Nullsafe.nonNull(new BigDecimal(this.bytes)
+                .divide(new BigDecimal(base), StorageUnit.DEFAULT_SCALE, RoundingMode.CEILING));
     }
 
     // Only exposed to be accessible by tests.


### PR DESCRIPTION
There is a constructor for `BigDecimal` which directly takes `BigInteger`. It is more efficient than printing the string and re-parsing it. It can make a slight difference in the scale that is used but the division sets the scale anyway.